### PR TITLE
Replace cache_timeout with max_age

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,20 @@
+3.0.4
+-----
+- Fix compatibility with Flask 2.2.0
+- Fix compatibility issue with itsdangerous
+- Update handle_request
+- Add _find_img
+- Add get_aspect_ratio
+- Add calculate_height
+
+3.0.3
+-----
+- Add svg minify options
+- Fix compatibility issue with itsdangerous
+- Update handle_request
+- Add _find_img
+- Add get_aspect_ratio
+- Add calculate_height
 
 3.0.2
 -----

--- a/flask_image_resizer/core.py
+++ b/flask_image_resizer/core.py
@@ -441,7 +441,7 @@ class Images(object):
             cache_mtime = os.path.getmtime(cache_path) if os.path.exists(cache_path) else None
 
         mimetype = 'image/%s' % format
-        cache_timeout = 31536000 if has_version else current_app.config['IMAGES_MAX_AGE']
+        max_age = 31536000 if has_version else current_app.config['IMAGES_MAX_AGE']
 
         if not use_cache or not cache_mtime or cache_mtime < raw_modified_time:
 
@@ -471,7 +471,7 @@ class Images(object):
                     image.save(fh, format, quality=quality)
                     return fh.getvalue(), 200, [
                         ('Content-Type', mimetype),
-                        ('Cache-Control', str(cache_timeout)),
+                        ('Cache-Control', str(max_age)),
                     ]
 
                 makedirs(cache_dir)
@@ -479,7 +479,7 @@ class Images(object):
                 image.save(cache_file, format, quality=quality)
                 cache_file.close()
 
-        return send_file(cache_path, mimetype=mimetype, cache_timeout=cache_timeout)
+        return send_file(cache_path, mimetype=mimetype, max_age=max_age)
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
 
     name='Flask-Image-Resizer',
-    version='3.0.3',
+    version='3.0.4',
     description='Dynamic image resizing for Flask.',
     url='http://github.com/mikeboers/Flask-Images',
         


### PR DESCRIPTION
This PR arises from issue #4 

## Tested in my local repo

1. To reproduce the local error, update flask and werkzeug versions in requirements.txt:
```
Flask==2.2.0
Werkzeug==2.2.2
```

2. I run the local server and visit http://[local_server] (which uses Flask-Image-Resizer), getting the expected error
```
TypeError: send_file() got an unexpected keyword argument 'cache_timeout'
```

3. I remove the current version of Flask-Image-Resizer

4. I update requirements.txt to install Flask-Image-Resizer from the current branch:
```
git+https://github.com/shuttle99ou/Flask-Image-Resizer.git@4_upgrade_old_names
```

5. I reinstall Flask-Image-Resizer from github and visit http://[local_server] (as well as some other urls from the same project), and see no further errors.

