### PR TITLE
Cast calculate_height as int

### DIFF
--- a/flask_image_resizer/core.py
+++ b/flask_image_resizer/core.py
@@ -588,4 +588,4 @@ def get_aspect_ratio(path, filename):
 @lru_cache(maxsize=1024)
 def calculate_height(path, filename, width=100):
     aspect_ratio = get_aspect_ratio(path, filename)
-    return width / aspect_ratio if aspect_ratio else "auto"
+    return int(width / aspect_ratio) if aspect_ratio else "auto"


### PR DESCRIPTION
This PR arises from issue #6 

## Tested in my local repo
1. I go to misolvencia.es (which uses Flask-Image-Resizer 3.0.4)

2. Using the developer tools, I inspect the website, to see the current behavior (height has decimals)
![image](https://user-images.githubusercontent.com/69116761/193963703-3c7ba984-f316-4575-b13e-e8b4cf9a6835.png)

3. I remove the current version of Flask-Image-Resizer

4. I update requirements.txt to install Flask-Image-Resizer from the current branch:
```
git+https://github.com/shuttle99ou/Flask-Image-Resizer.git@6_html_validation_errors
```

5. I reinstall Flask-Image-Resizer from github and visit http://[local_server]

6. There I see that the height now is an integer
![image](https://user-images.githubusercontent.com/69116761/193963664-5d5eaf74-2425-47d0-b8ef-0976f27d4c99.png)

