### PR TITLE
ANTIALIAS is deprecated #9

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+3.0.6
+-----
+- Fix compatibility with Pillow 10.0.0 (ANTIALIAS is deprecated, using LANCZOS instead)
+
 3.0.5
 -----
 - Fix calculate_height to return an integer

--- a/flask_image_resizer/core.py
+++ b/flask_image_resizer/core.py
@@ -288,13 +288,13 @@ class Images(object):
         
         # Handle the easy cases.
         if size.mode in (modes.RESHAPE, None) or size.req_width is None or size.req_height is None:
-            return image.resize((size.width, size.height), Image.ANTIALIAS)
+            return image.resize((size.width, size.height), Image.LANCZOS)
 
         if size.mode not in (modes.FIT, modes.PAD, modes.CROP):
             raise ValueError('unknown mode %r' % size.mode)
 
         if image.size != (size.op_width, size.op_height):
-            image = image.resize((size.op_width, size.op_height), Image.ANTIALIAS)
+            image = image.resize((size.op_width, size.op_height), Image.LANCZOS)
         
         if size.mode == modes.FIT:
             return image

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
 
     name='Flask-Image-Resizer',
-    version='3.0.5',
+    version='3.0.6',
     description='Dynamic image resizing for Flask.',
     url='http://github.com/mikeboers/Flask-Images',
         


### PR DESCRIPTION
Related to issue #9 

Here's a list of deprecations and removals, and what we can use instead:
https://pillow.readthedocs.io/en/stable/deprecations.html#constants

More info about the error in the issue.

**How did you test the issue?**

I modified the library locally in order to test it, with the same changes I'm introducing here:
![image](https://github.com/shuttle99ou/Flask-Image-Resizer/assets/24327796/7b2dfb50-b3fc-46f8-b10b-095903f5d2d9)

And the error is not present anymore:
```
[2023-10-19 21:28:34,238] DEBUG: ~/../website_apps/../static/images-in-repo/logos_websites/<company>-logo.png [in /../.local/lib/python3.10/site-packages/flask_image_resizer/core.py:573]
[2023-10-19 21:28:34,262] DEBUG: ~/../website_apps/../static/images-in-repo/logos_websites/<company>-logo-greenbg.png [in /../.local/lib/python3.10/site-packages/flask_image_resizer/core.py:573]
```

Also the image is showing up correctly now.