### PR TITLE
Dependencies and 3.0.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ MANIFEST
 
 /venv*
 /docs/_build
+
+.idea/
+build/

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,8 @@
 3.0.6
 -----
 - Fix compatibility with Pillow 10.0.0 (ANTIALIAS is deprecated, using LANCZOS instead)
+- Add scour requirement to setup.py
+- Pin dependencies on setup.py
 
 3.0.5
 -----

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,11 @@ setup(
     packages=['flask_image_resizer'],
 
     install_requires=[
-
         'Flask>=0.9',
-        'itsdangerous', # For Flask v0.9
-
-        'Pillow',
-        
-        'six',
-
+        'itsdangerous==2.1.2',  # For Flask v0.9
+        'Pillow==10.2.0',
+        'six==1.16.0',
+        'scour==0.38.2',
     ],
 
     classifiers=[


### PR DESCRIPTION
I'll pin the dependencies just to be on the safe side. The downside is that we will have to manually check when there's an update.

Maybe we can start using dependabot? https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file