### PR TITLE
Update demo - Get format from Pillow - Update requirements for demo

### DIFF
--- a/demo/main.py
+++ b/demo/main.py
@@ -1,5 +1,5 @@
 from flask import Flask, request, redirect, render_template
-from flask.ext.images import Images
+from flask_image_resizer import Images
 
 
 app = Flask(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 # Demo requirements.
-gunicorn
+gunicorn==21.2.0
+flask==3.0.2
+
 -e .


### PR DESCRIPTION
We had some issues with format. There was some weird code we used for getting the format, so instead we should use Pillow for this. This fixes the problem with `mode=pad` and `enlarge`:
![Screenshot 2024-03-17 at 09 35 04](https://github.com/shuttle99ou/Flask-Image-Resizer/assets/24327796/726464f4-8d67-4597-b9ff-e5975778b611)
![Screenshot 2024-03-17 at 09 35 15](https://github.com/shuttle99ou/Flask-Image-Resizer/assets/24327796/dd574019-eac4-4e79-98ca-f9c179325650)

The one thing I'm not sure about is what enlarge should be doing. It looks the same to me.

With enlarge:
![image](https://github.com/shuttle99ou/Flask-Image-Resizer/assets/24327796/8e56f4d3-abd5-4295-bb9d-5448326f3811)

Without:
![image](https://github.com/shuttle99ou/Flask-Image-Resizer/assets/24327796/ec53a292-b430-4f33-a5a6-854530c9d34c)

We should probably test it a bit more.